### PR TITLE
Nova Bitcoin adresa cez vanitygen, ktora zacina na 1pbar. Privatny kluc m

### DIFF
--- a/app/views/pages/join.html.erb
+++ b/app/views/pages/join.html.erb
@@ -70,7 +70,7 @@
       <abbr title="<%= t('.for_payments_from_abroad') %>">IBAN</abbr>: SK1583300000002600121198<br />
 		BIC/SWIFT: FIOZSKBAXXX</p>
     <p>
-      		Bitcoin: 18qKmRKFTGzdEW5GiBnwmCdLN54813ceN3
+      		Bitcoin: 1pbarBA4zP1bbCRydBUxweQxVfsaAHqDo
     </p>
     <p class="msg info note">
 		<img class="ui-icon ui-icon-info" src="/images/s.gif" alt="info icon">


### PR DESCRIPTION
Nova Bitcoin adresa cez vanitygen, ktora zacina na 1pbar. Privatny kluc ma momentalne wilder a juraj.
